### PR TITLE
Úprava reportu rozpis členských příspvěků a celkem zaplaceno

### DIFF
--- a/DSDD.Automations.Hosting/HostBuilderExtensions.cs
+++ b/DSDD.Automations.Hosting/HostBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Core;
+﻿using System.Globalization;
+using Azure.Core;
 using Azure.Identity;
 using DSDD.Automations.Hosting.Middleware;
 using Microsoft.Azure.Functions.Worker;
@@ -14,6 +15,12 @@ public static class HostBuilderExtensions
         Action<IFunctionsWorkerApplicationBuilder>? configure = null)
         => hostBuilder.ConfigureFunctionsWebApplication(app =>
         {
+            CultureInfo csCz = CultureInfo.GetCultureInfo("cs-CZ");
+            CultureInfo.DefaultThreadCurrentCulture = csCz;
+            CultureInfo.DefaultThreadCurrentUICulture = csCz;
+            CultureInfo.CurrentCulture = csCz;
+            CultureInfo.CurrentUICulture = csCz;
+
             app.UseMiddleware<ClaimsPrincipalPoplulatingMiddleware>();
 
             configure?.Invoke(app);

--- a/DSDD.Automations.Reports.Tests/DSDD.Automations.Reports.Tests.csproj
+++ b/DSDD.Automations.Reports.Tests/DSDD.Automations.Reports.Tests.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\DSDD.Automations.Reports\DSDD.Automations.Reports.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Reports\MemberFees\" />
+  </ItemGroup>
+</Project>

--- a/DSDD.Automations.Reports.Tests/Reports/MemberFees/MonthYearTests.cs
+++ b/DSDD.Automations.Reports.Tests/Reports/MemberFees/MonthYearTests.cs
@@ -1,0 +1,182 @@
+﻿using System.Collections;
+using DSDD.Automations.Reports.Reports.MemberFees;
+
+namespace DSDD.Automations.Reports.Tests.Reports.MemberFees;
+
+public class MonthYearTests
+{
+    public static IEnumerable Equals_Srouce
+    {
+        get
+        {
+            MonthYear left = new(10, 2024);
+            MonthYear right = new(10, 2024);
+            bool expected = true;
+
+            yield return new object[] { left, right, expected };
+
+            left = new(9, 2024);
+            right = new(10, 2024);
+            expected = false;
+
+            yield return new object[] { left, right, expected };
+
+            left = new(10, 2023);
+            right = new(10, 2024);
+            expected = false;
+
+            yield return new object[] { left, right, expected };
+        }
+    }
+
+    [TestCaseSource(nameof(Equals_Srouce))]
+    public void Equals(MonthYear left, MonthYear right, bool expected)
+    {
+        Assert.That(left == right, Is.EqualTo(expected));
+        Assert.That(left.Equals(right), Is.EqualTo(expected));
+    }
+
+    public static IEnumerable NotEquals_Source
+    {
+        get
+        {
+            MonthYear left = new(10, 2024);
+            MonthYear right = new(10, 2024);
+            bool expected = false;
+
+            yield return new object[] { left, right, expected };
+
+            left = new(9, 2024);
+            right = new(10, 2024);
+            expected = true;
+
+            yield return new object[] { left, right, expected };
+        }
+    }
+
+    [TestCaseSource(nameof(NotEquals_Source))]
+    public void NotEquals(MonthYear left, MonthYear right, bool expected)
+    {
+        Assert.That(left != right, Is.EqualTo(expected));
+    }
+
+    public static IEnumerable Greater_Source
+    {
+        get
+        {
+            MonthYear left = new(9, 2024);
+            MonthYear right = new(10, 2024);
+            bool expected = false;
+
+            yield return new object[] { left, right, expected };
+
+            left = new(10, 2024);
+            right = new(10, 2024);
+            expected = false;
+
+            yield return new object[] { left, right, expected };
+
+            left = new(11, 2024);
+            right = new(10, 2024);
+            expected = true;
+
+            yield return new object[] { left, right, expected };
+        }
+    }
+
+    [TestCaseSource(nameof(Greater_Source))]
+    public void Greater(MonthYear left, MonthYear right, bool expected)
+    {
+        Assert.That(left > right, Is.EqualTo(expected));
+    }
+
+    public static IEnumerable GreaterOrEqual_Source
+    {
+        get
+        {
+            MonthYear left = new(9, 2024);
+            MonthYear right = new(10, 2024);
+            bool expected = false;
+
+            yield return new object[] { left, right, expected };
+
+            left = new(10, 2024);
+            right = new(10, 2024);
+            expected = true;
+
+            yield return new object[] { left, right, expected };
+
+            left = new(11, 2024);
+            right = new(10, 2024);
+            expected = true;
+
+            yield return new object[] { left, right, expected };
+        }
+    }
+
+    [TestCaseSource(nameof(GreaterOrEqual_Source))]
+    public void GreaterOrEqual(MonthYear left, MonthYear right, bool expected)
+    {
+        Assert.That(left >= right, Is.EqualTo(expected));
+    }
+
+    public static IEnumerable Lower_Source
+    {
+        get
+        {
+            MonthYear left = new(9, 2024);
+            MonthYear right = new(10, 2024);
+            bool expected = true;
+
+            yield return new object[] { left, right, expected };
+
+            left = new(10, 2024);
+            right = new(10, 2024);
+            expected = false;
+
+            yield return new object[] { left, right, expected };
+
+            left = new(11, 2024);
+            right = new(10, 2024);
+            expected = false;
+
+            yield return new object[] { left, right, expected };
+        }
+    }
+
+    [TestCaseSource(nameof(Lower_Source))]
+    public void Lower(MonthYear left, MonthYear right, bool expected)
+    {
+        Assert.That(left < right, Is.EqualTo(expected));
+    }
+
+    public static IEnumerable LowerOrEqual_Source
+    {
+        get
+        {
+            MonthYear left = new(9, 2024);
+            MonthYear right = new(10, 2024);
+            bool expected = true;
+
+            yield return new object[] { left, right, expected };
+
+            left = new(10, 2024);
+            right = new(10, 2024);
+            expected = true;
+
+            yield return new object[] { left, right, expected };
+
+            left = new(11, 2024);
+            right = new(10, 2024);
+            expected = false;
+
+            yield return new object[] { left, right, expected };
+        }
+    }
+
+    [TestCaseSource(nameof(LowerOrEqual_Source))]
+    public void LowerOrEqual(MonthYear left, MonthYear right, bool expected)
+    {
+        Assert.That(left <= right, Is.EqualTo(expected));
+    }
+}

--- a/DSDD.Automations.Reports.Tests/Reports/MemberFees/PayerPaymentsPerMonthTests.cs
+++ b/DSDD.Automations.Reports.Tests/Reports/MemberFees/PayerPaymentsPerMonthTests.cs
@@ -1,0 +1,45 @@
+﻿using DSDD.Automations.Payments.Model;
+using DSDD.Automations.Reports.Reports.MemberFees;
+
+namespace DSDD.Automations.Reports.Tests.Reports.MemberFees;
+
+public class PayerPaymentsPerMonthTests
+{
+    [Test]
+    public void Get()
+    {
+        // Setup
+        DateTime now = DateTime.Now;
+        DateTime monthAgo = now.AddMonths(-1);
+        DateTime monthNext = now.AddMonths(1);
+        const ulong CONSTANT_SYMBOL = 100;
+
+        Payer payer = new(10);
+        payer.BankPayments.Add(new("foo", "bar", 50, 800, monthAgo, null, new(false, null, null, null)));
+        payer.BankPayments.Add(new("foo", "bar", CONSTANT_SYMBOL, 120, monthAgo, null, new(false, null, null, null)));
+        payer.BankPayments.Add(new("foo", "bar", 50, 100, now, null, new(false, null, null, null)));
+        payer.BankPayments.Add(new("foo", "bar", CONSTANT_SYMBOL, 300, now, null, new(false, null, null, null)));
+        payer.BankPayments.Add(new("foo", "bar", CONSTANT_SYMBOL, 180, now, null, new(true, null, null, null)));
+        payer.BankPayments.Add(new("foo", "bar", 50, 810, monthNext, null, new(false, null, null, null)));
+        payer.BankPayments.Add(new("foo", "bar", CONSTANT_SYMBOL, 170, monthNext, null, new(false, null, null, null)));
+
+        payer.ManualPayments.Add(new("foo", 50, 200, monthAgo, null));
+        payer.ManualPayments.Add(new("foo", CONSTANT_SYMBOL, 200, monthAgo, null));
+        payer.ManualPayments.Add(new("foo", 50, 550, now, null));
+        payer.ManualPayments.Add(new("foo", CONSTANT_SYMBOL, 120, now, null));
+        payer.ManualPayments.Add(new("foo", 50, 200, monthNext, null));
+        payer.ManualPayments.Add(new("foo", CONSTANT_SYMBOL, 200, monthNext, null));
+
+        PayerPaymentsPerMonth sut = new(payer, CONSTANT_SYMBOL);
+
+        // Act
+        decimal resultMonthAgo = sut.Get(new(monthAgo));
+        decimal resultNow = sut.Get(new(now));
+        decimal resultMonthNext = sut.Get(new(monthNext));
+
+        // Assert
+        Assert.That(resultMonthAgo, Is.EqualTo(320));
+        Assert.That(resultNow, Is.EqualTo(420));
+        Assert.That(resultMonthNext, Is.EqualTo(370));
+    }
+}

--- a/DSDD.Automations.Reports/Reports/ClosedXmlHelpers.cs
+++ b/DSDD.Automations.Reports/Reports/ClosedXmlHelpers.cs
@@ -77,7 +77,7 @@ public static class ClosedXmlHelpers
 
         // Datetime is too narrow when auto adjusted and must be expanded.
         foreach (IXLColumn dateTimeColumn in dateTimeColumns)
-            dateTimeColumn.Width += 1;
+            dateTimeColumn.Width += 2;
 
         return SaveToMemory(workbook);
 

--- a/DSDD.Automations.Reports/Reports/ClosedXmlPayedTotalReport.cs
+++ b/DSDD.Automations.Reports/Reports/ClosedXmlPayedTotalReport.cs
@@ -30,6 +30,7 @@ public class ClosedXmlPayedTotalReport: IPayedTotalReport
                     return new SummedPayer(payer.VariableSymbol, total);
                 return new SummedPayer(member.FirstName, member.LastName, member.VariableSymbol, total);
             })
+            .Where(p => p.AmountCzk != 0)
             .OrderBy(p => p.LastName)
             .ToArrayAsync(ct);
 

--- a/DSDD.Automations.Reports/Reports/MemberFees/ClosedXmlMemberFeesReport.cs
+++ b/DSDD.Automations.Reports/Reports/MemberFees/ClosedXmlMemberFeesReport.cs
@@ -108,7 +108,7 @@ public class ClosedXmlMemberFeesReport: IMemberFeesReport
             field.TotalsRowFunction = XLTotalsRowFunction.Sum;
         IXLRangeRow totalsRow = table.TotalsRow();
         totalsRow.Style.Font.FontColor = XLColor.Black;
-        totalsRow.Style.Font.Bold = true;
+        totalsRow.Style.Font.Bold = false;
         
         table
             .Range(2, 3, table.LastRow().RowNumber(), 3)

--- a/DSDD.Automations.Reports/Reports/MemberFees/PayerPaymentsPerMonth.cs
+++ b/DSDD.Automations.Reports/Reports/MemberFees/PayerPaymentsPerMonth.cs
@@ -9,7 +9,10 @@ public struct PayerPaymentsPerMonth
         _perMonth = payer
             .ManualPayments
             .Select(p => (p.DateTime, p.ConstantSymbol, p.AmountCzk))
-            .Concat(payer.BankPayments.Select(p => (p.DateTime, p.ConstantSymbol, p.AmountCzk)))
+            .Concat(payer
+                .BankPayments
+                .Where(p => !p.Overrides.Removed)
+                .Select(p => (p.DateTime, p.ConstantSymbol, p.AmountCzk)))
             .Where(p => p.ConstantSymbol == constantSymbol)
             .Select(p => (new MonthYear(p.DateTime), p.AmountCzk))
             .GroupBy(p => p.Item1, p => p.AmountCzk)

--- a/DSDD.Automations.sln
+++ b/DSDD.Automations.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DSDD.Automations.Reports", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DSDD.Automations.Hosting", "DSDD.Automations.Hosting\DSDD.Automations.Hosting.csproj", "{A785BBDF-0E56-4848-8300-FBCD353356BE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DSDD.Automations.Reports.Tests", "DSDD.Automations.Reports.Tests\DSDD.Automations.Reports.Tests.csproj", "{40897BC6-CF7C-466B-957F-F3C7378C6561}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,6 +66,10 @@ Global
 		{A785BBDF-0E56-4848-8300-FBCD353356BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A785BBDF-0E56-4848-8300-FBCD353356BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A785BBDF-0E56-4848-8300-FBCD353356BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40897BC6-CF7C-466B-957F-F3C7378C6561}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40897BC6-CF7C-466B-957F-F3C7378C6561}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40897BC6-CF7C-466B-957F-F3C7378C6561}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40897BC6-CF7C-466B-957F-F3C7378C6561}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Doplněny unit testy
- Nastavena cs-CZ kultura aby se datumy, chyby a další .NET built-in věci lokalizovali do ČJ (nwm jestli tahle kultura je dostupna v Azure Funkcích).

**Rozpis členských příspvěků**
- U přihlášených, kteří ještě nezaplatili (a tak nejsou členy) je žlutý text "Bez 1. platby" a nebo žlutě částka pokud zaplatili méně než je příspěvek. Od momentu kdy zaplatí příspěvek jsou další buňky buď zelené nebo červené (nezaplatili příspěvek). **Členství vzniká první platbou a s tím povinnost platit další platby.**
- Přidána řádka se součty

![image](https://github.com/user-attachments/assets/19888661-60a0-4bb4-aced-be58ed76ec7c)

**Celkem zaplaceno**
- neukazují se záznamy pro lidi co zaplatili 0