### PR TITLE
Timer funkce RbczImport.Timer je konfigurovatelný z konfigu

### DIFF
--- a/DSDD.Automations.Payments/RbczImport.cs
+++ b/DSDD.Automations.Payments/RbczImport.cs
@@ -1,4 +1,4 @@
-using DSDD.Automations.Payments.RBCZ;
+﻿using DSDD.Automations.Payments.RBCZ;
 using DSDD.Automations.Payments.Durable;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.DurableTask;
@@ -14,7 +14,7 @@ public class RbczImport
     }
 
     [Function(nameof(RbczImport) + "-" + nameof(Timer))]
-    public Task Timer([TimerTrigger("0 0 1 * * *")] TimerInfo myTimer, [DurableClient] DurableTaskClient client, CancellationToken ct)
+    public Task Timer([TimerTrigger("%RBCZ_IMPORT_TIMER_CRON%")] TimerInfo myTimer, [DurableClient] DurableTaskClient client, CancellationToken ct)
         => client.ScheduleNewMethodOrchestrationInstanceAsync<RbczImport>(_ => _.Orhcestration(default!));
 
     [Function(nameof(RbczImport) + "-" + nameof(Orhcestration))]
@@ -26,6 +26,7 @@ public class RbczImport
         // Cannot be named _ (discard) as this name is prohibited in Azure Functions.
         [ActivityTrigger] TaskActivityContext context,
         CancellationToken ct)
+        // TODO: rozbít importer na dílčí aktivity funkce.
         => _importer.ImportAsync(ct);
 
     private IBankPaymentsImporter _importer;

--- a/DSDD.Automations.sln
+++ b/DSDD.Automations.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DSDD.Automations.Payments.Common", "DSDD.Automations.Payments.Common\DSDD.Automations.Payments.Common.csproj", "{F874C1AA-53CA-49A2-A8A8-107D20880889}"
@@ -26,7 +27,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DSDD.Automations.Reports", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DSDD.Automations.Hosting", "DSDD.Automations.Hosting\DSDD.Automations.Hosting.csproj", "{A785BBDF-0E56-4848-8300-FBCD353356BE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DSDD.Automations.Reports.Tests", "DSDD.Automations.Reports.Tests\DSDD.Automations.Reports.Tests.csproj", "{40897BC6-CF7C-466B-957F-F3C7378C6561}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DSDD.Automations.Reports.Tests", "DSDD.Automations.Reports.Tests\DSDD.Automations.Reports.Tests.csproj", "{40897BC6-CF7C-466B-957F-F3C7378C6561}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Create `local.settings.json`.
 
     "COSMOS_DB_ACCOUNT_ENDPOINT": "From payments-db-dev",
 
+    "RBCZ_IMPORT_TIMER_CRON": "0 0 1 * * *",
+
     "RBCZ_CLIENT_ID": "Copy from production Functions App in Azure Portal",
     "RBCZ_AUDIT_IP_ADDRESS": "255.255.255.255",
     "RBCZ_ACCOUNT_NUMBER": "1899051002",


### PR DESCRIPTION
Do teď měl natvrdo že se pouští v 1 ráno zulu. RBCZ API nění vždy v tento čas dostupné. Teď to půjde jedndouše upravovat bez nutnosti přebuildid aplikaci.