### PR TITLE
V případě že transakce neobsahuje var. symbol, konst. symbol, zprávu pro příjemce apod. chybí objekt remittanceInfomration

### DIFF
--- a/DSDD.Automations.Payments.RBCZ/BankPaymentsImporter.cs
+++ b/DSDD.Automations.Payments.RBCZ/BankPaymentsImporter.cs
@@ -53,7 +53,7 @@ internal class BankPaymentsImporter: IBankPaymentsImporter
                 string? variableSymbolRaw = transaction
                     .EntryDetails
                     .TransactionDetails
-                    .RemittanceInformation
+                    .RemittanceInformation?
                     .CreditorReferenceInformation?
                     .Variable;
 


### PR DESCRIPTION
Přidání null chain operatoru.